### PR TITLE
Update Cosmos version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-astronomer-cosmos==1.0.4
+astronomer-cosmos
 astro-sdk-python==1.6.1


### PR DESCRIPTION
Since this is a public-facing repository, some customers are using it. Unfortunately, this ancient version of Cosmos (August 2023) has several bugs and problems.

@TJaniF any chance we could unify this repo with https://github.com/astronomer/cosmos-demo and not pin Cosmos?